### PR TITLE
Fix concealing for more codes

### DIFF
--- a/syntax/terminal.vim
+++ b/syntax/terminal.vim
@@ -11,7 +11,7 @@ endif
 
 " Simple syntax highlighting for UnicodeTable command {{{2
 syn match TerminalCSIColorCode1 /\[\d\+m/ conceal
-syn match TerminalCSIColorCode2 /\[\d\+;\d\+m/ conceal
+syn match TerminalCSIColorCode2 /\[\d\+\(;\d\+\)\+m/ conceal
 
 " Set the syntax variable
 let b:current_syntax="terminal"


### PR DESCRIPTION
I am also seeing `^[[38;5;30m` and `^[[1;38;5;208m` with
TERM=tmux-256color (tmux/kitty) and `lsd` (likely via `LS_COLORS`?).