### PR TITLE
More escape code support + some bug fixes

### DIFF
--- a/lua/terminal.lua
+++ b/lua/terminal.lua
@@ -173,19 +173,27 @@ local function create_highlight(attributes)
 end
 
 --- Highlight a region in a buffer from the attributes specified
-local function highlight_from_attributes(buf, ns, current_attributes,
-		 region_line_start, region_byte_start,
-		 region_line_end, region_byte_end)
+local function highlight_from_attributes(buf, ns, current_attributes, start_line, start_byte, end_line, end_byte)
 	-- TODO should I bother with highlighting normal regions?
 	local highlight_name = create_highlight(current_attributes)
-	if region_line_start == region_line_end then
-		nvim.buf_add_highlight(buf, ns, highlight_name, region_line_start, region_byte_start, region_byte_end)
+
+	local function highlight_line_region(line, column_start, column_end)
+		nvim.buf_add_highlight(buf, ns, highlight_name, line, column_start, column_end)
+	end
+
+	if start_line == end_line then
+		highlight_line_region(start_line, start_byte, end_byte)
 	else
-		nvim.buf_add_highlight(buf, ns, highlight_name, region_line_start, region_byte_start, -1)
-		for linenum = region_line_start + 1, region_line_end - 1 do
-			nvim.buf_add_highlight(buf, ns, highlight_name, linenum, 0, -1)
+		local start_of_line = 0
+		local end_of_line = -1
+
+		highlight_line_region(start_line, start_byte, end_of_line)
+
+		for linenum = start_line + 1, end_line - 1 do
+			highlight_line_region(linenum, start_of_line, end_of_line)
 		end
-		nvim.buf_add_highlight(buf, ns, highlight_name, region_line_end, 0, region_byte_end)
+
+		highlight_line_region(end_line, start_of_line, end_byte)
 	end
 end
 

--- a/lua/terminal.lua
+++ b/lua/terminal.lua
@@ -200,7 +200,7 @@ local function parse_color_code(rgb_color_table, code, current_attributes)
 	-- Currently, I'm going to accept the valid subsets and ignore the others.
 	local find_start = 1
 	while find_start <= #code do
-		local match_start, match_end = code:find(";", find_start, true)
+		local match_start, match_end = code:find("[;:]", find_start)
 		local segment = code:sub(find_start, match_start and match_start-1)
 		-- Parse until the end.
 		if not match_start then

--- a/lua/terminal.lua
+++ b/lua/terminal.lua
@@ -340,7 +340,7 @@ local function attach_to_buffer(buf, rgb_color_table)
 	do
 		nvim.buf_clear_namespace(buf, ns, 0, -1)
 		local lines = nvim.buf_get_lines(buf, 0, -1, true)
-		highlight_buffer(buf, ns, lines, 0)
+		highlight_buffer(buf, ns, lines, 0, rgb_color_table)
 	end
 	-- send_buffer: true doesn't actually do anything in Lua (yet)
 	nvim.buf_attach(buf, false, {
@@ -353,7 +353,7 @@ local function attach_to_buffer(buf, rgb_color_table)
 			new_lastline = -1
 			nvim.buf_clear_namespace(buf, ns, firstline, new_lastline)
 			local lines = nvim.buf_get_lines(buf, firstline, new_lastline, true)
-			highlight_buffer(buf, ns, lines, firstline)
+			highlight_buffer(buf, ns, lines, firstline, rgb_color_table)
 		end;
 	})
 end

--- a/lua/terminal.lua
+++ b/lua/terminal.lua
@@ -54,6 +54,38 @@ local function initialize_terminal_colors()
 	return result
 end
 
+--- Extracts currently active (set to true) attributes
+-- @tparam {[string]=bool} attributes states
+-- @treturn {string,...} array of active attributes
+local function get_active_attributes(attributes)
+	attributes = attributes or {}
+
+	local result = {}
+	for k, v in pairs(attributes) do
+		if v == true then
+			table.insert(result, k)
+		end
+	end
+	return result
+end
+
+--- Turns a attributes table into a delimited list
+-- @tparam {[string]=bool} attributes table of each attribute's state
+-- @tparam[opt=','] string delim value used as list delimiter
+-- @treturn string list of attributes or NONE if attributes were empty
+local function get_attribute_list(attributes, delim)
+	attributes = attributes or {}
+	delim = delim or ','
+
+	local result = table.concat(get_active_attributes(attributes), delim)
+
+	if result == '' then
+		result = 'NONE'
+	end
+
+	return result
+end
+
 --- Parses a list of codes into an object of cterm/gui attributes
 -- @tparam {[number]=string} rgb_color_table cterm color RGB lookup table
 -- @tparam {string|int,...} attrs the list of codes numbers like 0 from ^[[0m
@@ -64,7 +96,6 @@ local function resolve_attributes(rgb_color_table, attrs, attributes)
 	for _, v in ipairs(attrs) do
 		v = tonumber(v)
 		-- @todo The color codes implemented is not complete
-		-- @todo cterm and gui can have multiple values for italics/things other than bold.
 		if not v then
 			-- TODO print warning here? It might be spammy.
 			-- nvim.err_writeln("Invalid mode encountered")
@@ -88,9 +119,6 @@ local function resolve_attributes(rgb_color_table, attrs, attributes)
 			local ctermbg = v-100+8
 			attributes.ctermbg = ctermbg
 			attributes.guibg = rgb_color_table[ctermbg]
-		elseif v == 22 then
-			attributes.cterm = 'NONE'
-			attributes.gui = 'NONE'
 		elseif v == 39 then
 			-- Reset to normal color for foreground
 			attributes.ctermfg = 'fg'
@@ -99,9 +127,41 @@ local function resolve_attributes(rgb_color_table, attrs, attributes)
 			-- Reset to normal color for background
 			attributes.ctermbg = 'bg'
 			attributes.guibg = 'bg'
-		elseif v == 1 then
-			attributes.cterm = 'bold'
-			attributes.gui = 'bold'
+		elseif v >= 1 and v <= 29 then
+			attributes.cterm = attributes.cterm or {}
+			attributes.gui = attributes.gui or {}
+
+			if v == 9 then
+				attributes.cterm.strikethrough = true
+				attributes.gui.strikethrough = true
+			elseif v == 29 then
+				attributes.cterm.strikethrough = false
+				attributes.gui.strikethrough = false
+			elseif v == 7 then
+				attributes.cterm.reverse = true
+				attributes.gui.reverse = true
+			elseif v == 27 then
+				attributes.cterm.reverse = false
+				attributes.gui.reverse = false
+			elseif v == 4 then
+				attributes.cterm.underline = true
+				attributes.gui.underline = true
+			elseif v == 24 then
+				attributes.cterm.underline = false
+				attributes.gui.underline = false
+			elseif v == 3 then
+				attributes.cterm.italic = true
+				attributes.gui.italic = true
+			elseif v == 23 then
+				attributes.cterm.italic = false
+				attributes.gui.italic = false
+			elseif v == 1 then
+				attributes.cterm.bold = true
+				attributes.gui.bold = true
+			elseif v == 22 then
+				attributes.cterm.bold = false
+				attributes.gui.bold = false
+			end
 		elseif v == 0 then
 			-- RESET
 			attributes = {}
@@ -113,7 +173,11 @@ end
 local function format_attributes(attributes)
 	local result = {}
 	for k, v in pairs(attributes) do
-		table.insert(result, k.."="..v)
+		if type(v) == "string" then
+			table.insert(result, k.."="..v)
+		elseif type(v) == "table" then
+			table.insert(result, k.."="..get_attribute_list(v))
+		end
 	end
 	return result
 end
@@ -125,7 +189,7 @@ local function make_highlight_name(attributes)
 	local result = {HIGHLIGHT_NAME_PREFIX}
 	if attributes.cterm then
 		table.insert(result, "c")
-		table.insert(result, attributes.cterm)
+		table.insert(result, get_attribute_list(attributes.cterm, '_'))
 	end
 	if attributes.ctermfg then
 		table.insert(result, "cfg")
@@ -137,7 +201,7 @@ local function make_highlight_name(attributes)
 	end
 	if attributes.gui then
 		table.insert(result, "g")
-		table.insert(result, attributes.gui)
+		table.insert(result, get_attribute_list(attributes.gui, '_'))
 	end
 	if attributes.guifg then
 		table.insert(result, "gfg")
@@ -394,14 +458,14 @@ local function test_parse()
 	local tests = {
 		["0;38;5;100"] = table_is_empty;
 		["1;33"]       = resolve_attributes(rgb_color_table, {1,33}, {});
-		["1;38;5;100"] = { cterm = 'bold'; ctermfg = 100; guifg = rgb_color_table[100]; };
+		["1;38;5;100"] = { cterm = { ['bold'] = true }; ctermfg = 100; guifg = rgb_color_table[100]; };
 		["1;38;5;3"]   = resolve_attributes(rgb_color_table, {1,33}, {});
 		["1;48;5;3"]   = resolve_attributes(rgb_color_table, {1,43}, {});
 		["30"]         = resolve_attributes(rgb_color_table, {30}, {});
 		["30"]         = resolve_attributes(rgb_color_table, {30}, {});
 		["38;123;432"] = table_is_empty;
 		["38;5;100;0"] = table_is_empty; -- TODO is this really correct?
-		["38;5;100;1"] = { cterm = 'bold'; ctermfg = 100; guifg = rgb_color_table[100]; };
+		["38;5;100;1"] = { cterm = { ['bold'] = true }; ctermfg = 100; guifg = rgb_color_table[100]; };
 		["38;5;100"]   = { ctermfg = 100; guifg = rgb_color_table[100]; };
 		["38;5;3"]     = resolve_attributes(rgb_color_table, {33}, {});
 		["38;5;543"]   = table_is_empty;

--- a/lua/terminal.lua
+++ b/lua/terminal.lua
@@ -414,6 +414,12 @@ local function attach_to_buffer(buf, rgb_color_table)
 		local lines = nvim.buf_get_lines(buf, 0, -1, true)
 		highlight_buffer(buf, ns, lines, 0, rgb_color_table)
 	end
+
+	-- remove the limit on syntax highlighting long lines
+	-- without this lines that are longer then the default value
+	-- stop being hidden with conceal leaking terminal escape codes
+	nvim.buf_set_option(buf, 'synmaxcol', 0)
+
 	-- send_buffer: true doesn't actually do anything in Lua (yet)
 	nvim.buf_attach(buf, false, {
 		on_lines = function(event_type, buf, changed_tick, firstline, lastline, new_lastline)


### PR DESCRIPTION
Commit Overview:

### Allow colons as argument seperators
this one is pretty self explanatory it allows for colons (`:`) to be used in place of semicolons (`;`) in escape codes

### Pass color table
this fixes a bug you mentioned in another PR where you forgot to pass in the color table given to attach_to_buffer to highlight_buffer

### Make function highlight_from_attributes more readable
this was just so I could understand it better as I was implementing the next commit

### Support for common attributes
this is the big one with the most changes.
the way I went about this was replacing the previous way of setting the current text attribute which was just a string that cterm and gui were set to, with a table of [string] = boolean.

the string part is the attribute name and the boolean part is if that current attribute is active.
I chose this because it seemed like the simplest way to easily be able to toggle an attribute.

when the table is required as a string the values that are true are picked out and concatenated into a list delimited by commas (`,`) for the syntax highlighting or into a list delimited by underscores (`_`) for the highlight group name generator

this should fix #8 but there isn't really a list and tbh I don't understand what blueyed was talking about so maybe this commit has nothing to do with #8 at all :?...

### Escape codes being leaked
sets synmaxcol to 0 so it doesn't stop after column 3000

this one I spent a long time trying to figure out what wrong and only after finding 'synmaxcol' did I find your comment speculating about it :/

should fix  #11 
